### PR TITLE
Add reference to Japanese translation on the homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,6 +13,7 @@
 <div class="sectionbody">
   <p>rbenv is a version manager tool for the Ruby programming language on Unix-like systems. It is useful for switching between multiple Ruby versions on the same machine and for ensuring that each project you are working on always runs on the correct Ruby version.</p>
   <p>For more information, see <a href="https://github.com/rbenv/rbenv#readme">github.com/rbenv/rbenv</a></p>
+  <p>Translations: <a href="https://gemmaro.github.io/rbenv.github.io/">日本語 (Japanese)</a></p>
 </div>
 <h2 id="install">Installation</h2>
 <div class="sectionbody">


### PR DESCRIPTION
Hello,

I've translated the following rbenv-related repositories into Japanese to support Japanese-speaking developers:

- [rbenv.github.io](https://github.com/gemmaro/rbenv.github.io)
- [rbenv](https://github.com/gemmaro/rbenv)
- [ruby-build](https://github.com/gemmaro/ruby-build)

This adds a link to the Japanese translation page on the respective top page.

Thank you,